### PR TITLE
Fixed errors in any and pair notes

### DIFF
--- a/docs/src/binaryops.md
+++ b/docs/src/binaryops.md
@@ -40,8 +40,8 @@ All built-in binary operators can be found below:
 |:----------------|----------------:|------------------------------------------------------   |
 | `first`           | `FIRST`          | `first(x, y) = x`                                    |
 | `second`          | `SECOND`         | `second(x, y) = y`                                   |
-| `any`             | `ANY`            | `any(x, y) = 1` if `x` **or** `y` are stored values  |
-| `pair`            | `PAIR`           | `any(x, y) = 1` if `x` **and** `y` are stored values |
+| `any`             | `ANY`            | `any(x, y)` can return either `x` or `y`. The result is non-deterministic.|
+| `pair`            | `PAIR`           | `pair(x, y) = 1` if `x` **and** `y` are stored values|
 | `+`               | `PLUS`           |                                                      |
 | `-`               | `MINUS`          |                                                      |
 | `rminus`          | `RMINUS`         |                                                      |


### PR DESCRIPTION
Quick fix of the documentation to address #147 . 

A more detailed explanation of the behavior of any and pair, inspired from the SuiteSparseGraphBLAS users guide might be worth adding somewhere here too.